### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/Workflow.ts
+++ b/Workflow.ts
@@ -4,7 +4,7 @@
 import {GustavGraph} from './GustavGraph';
 import {gustav} from './index';
 import {Observable} from '@reactivex/rxjs';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 import {INodeDef, ISourceNode, ITransfNode, ISinkNode, IMetaConfig} from './defs';
 
 export interface IStrongNodeDef extends INodeDef {

--- a/couplers/GustavRabbit.ts
+++ b/couplers/GustavRabbit.ts
@@ -3,7 +3,7 @@
 import {Observable, Subscription} from '@reactivex/rxjs';
 import {ICoupler} from '../defs';
 import {connect} from 'amqplib';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 
 // Untested, use at own risk
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "@reactivex/rxjs": "5.0.0-beta.0",
     "amqplib": "^0.4.0",
     "kafka-node": "^0.3.1",
-    "node-uuid": "1.4.7",
     "redis": "2.5.x",
-    "tail": "1.1.x"
+    "tail": "1.1.x",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "~3.5.0",

--- a/test/GRabbit.ts
+++ b/test/GRabbit.ts
@@ -4,7 +4,7 @@ import {GustavRabbit} from '../couplers/GustavRabbit';
 import {Observable} from '@reactivex/rxjs';
 import {expect} from 'chai';
 import {connect} from 'amqplib';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 
 describe('GustavRabbit', () => {
   // Hacky way of doing integration testing


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.